### PR TITLE
29 simplify gistic import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,8 +48,9 @@ Imports:
     utilitybeltrna,
     PCAWGmutations,
     pheatmap,
-    pkgload
-Remotes: 
+    pkgload,
+    TCGAgistic (>= 0.0.0.9000)
+Remotes:  
     selkamand/utilitybeltassertions,
     selkamand/utilitybeltshiny,
     selkamand/utilitybeltlists,
@@ -58,7 +59,8 @@ Remotes:
     ebailey78/shinyBS,
     CCICB/somaticflags,
     CCICB/PCAWGmutations
-    selkamand/mutalisk
+    selkamand/mutalisk,
+    CCICB/TCGAgistic
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.2.1

--- a/R/mod_cnv.R
+++ b/R/mod_cnv.R
@@ -1,3 +1,5 @@
+df_tcga_gistic <- TCGAgistic::tcga_gistic_available()
+num_gistic_choices <- seq_len(nrow(df_tcga_gistic)) 
 #' cnv UI Function
 #'
 #' @description A shiny Module.
@@ -22,44 +24,50 @@ mod_cnv_ui <- function(id){
     
     # Step 2: Select GISTIC directory -----------------------------------------
     shinyWidgets::panel(
-      heading = HTML(paste0("Step 2: Select GISTIC files", as.character(select_gistic_help_icon()), sep = " ")),
-      fileInput(inputId = ns("in_file_lesions"), label = "All Lesions", multiple = FALSE, accept = ".txt", width = "100%") %>% col_3(),
-      fileInput(inputId = ns("in_file_amp"), label = "Amplified Genes", multiple = FALSE, accept = ".txt", width = "100%") %>% col_3(),
-      fileInput(inputId = ns("in_file_del"), label = "Deleted Genes", multiple = FALSE, accept = ".txt", width = "100%") %>% col_3(),
-      fileInput(inputId = ns("in_file_scores"), label = "Scores", multiple = FALSE, width = "100%") %>% col_3()
-    ),
-    icon_down_arrow(break_after = TRUE),
+      heading = "Step 2: Are you using inbuild GISTIC data or importing your own?",
+      shinyWidgets::radioGroupButtons(
+      inputId = ns("in_bttn_preloaded_or_user"),
+      label = "Label",
+      choices = c("Inbuilt", "Custom"),
+      justified = TRUE)
+    ), icon_down_arrow(break_after = TRUE),
     
-    # # Step 3: Check automatic identification of GISTIC files ------------------
-    # shinyWidgets::panel(
-    #   heading = HTML(paste0("Step 3: Check automatic identification of required gistic files is correct", "      ", gistic_help_icon())),
-    #   fluidRow(
-    #     shinyWidgets::pickerInput(inputId = ns("in_file_lesions"), label = "All Lesions", choices = NULL) %>% col_3(),
-    #     shinyWidgets::pickerInput(inputId = ns("in_file_amp"), label = "Amplified Genes", choices = NULL) %>% col_3(),
-    #     shinyWidgets::pickerInput(inputId = ns("in_file_del"), label = "Deleted Genes", choices = NULL) %>% col_3(),
-    #     shinyWidgets::pickerInput(inputId = ns("in_file_scores"), label = "Scores", choices = NULL) %>% col_3()
-    #     
-    #   )
-    # ),
-    # icon_down_arrow(break_after = TRUE),
-    
-    # Step 4: Configure Analysis ----------------------------------------------
     shinyWidgets::panel(
-      heading = "Step 4: Configure Analysis",
-      fluidRow(
-        shinyWidgets::awesomeCheckbox(inputId = ns("in_check_is_tcga"), label = "Data is from TCGA", value = FALSE) %>% 
-          bsplus::bs_embed_tooltip(title = "Is the GISTIC data from a TCGA project? If so, we truncate the Tumor_Sample_Barcodes to patient level rather than sequencing_run level",placement = "top") %>%
-          col_2(),
-        shinyWidgets::awesomeRadio(inputId = ns("in_check_cn_level"), label = HTML(paste0("cnLevel", icon(""))), choices = c("all", "deep", "shallow"), selected = "all", inline = TRUE) %>%
-          bsplus::bs_embed_tooltip(title = "Level of CN changes to use. Can be 'all', 'deep' or 'shallow'. Default uses all i.e, genes with both 'shallow' or 'deep' CN changes", placement="top") %>% 
-          col_4() 
+      heading = HTML(paste0("Step 3: Select GISTIC files", as.character(select_gistic_help_icon()), sep = " ")),
+    
+      tabsetPanel(id = ns("in_tabset"), type = "hidden",
+        tabPanelBody(
+          value = "Inbuilt",
+          shinyWidgets::pickerInput(
+            inputId = ns("in_pick_gistic"), 
+            label = "Select CNV dataset", 
+            choices = seq_len(nrow(df_tcga_gistic)) ,
+            options = list(title = "Please select a GISTIC dataset"),
+            choicesOpt = list(
+              content = paste0(
+                TCGAgistic::tcga_gistic_available()[[2]],
+                " ",
+                TCGAgistic::tcga_gistic_available()[[4]] %>% paste0("<span class='label label-default' style='margin-left: 10px; font-size: xx-small' >",., "</span>"),
+                " ",
+                TCGAgistic::tcga_gistic_available()[[1]] %>% paste0("<span class='label label-default' style='margin-left: 10px; font-size: xx-small' >",., "</span>"),
+                " ",
+                "TCGA" %>% paste0("<span class='label label-default' style='margin-left: 10px; font-size: xx-small' >",., "</span>")
+                
+              ) 
+            ))    
+          ),
+        tabPanelBody(
+          value = "Custom",
+          fileInput(inputId = ns("in_file_gistic"), label = "Select your GISTIC rds")
+         ),
       )
     ),
+    
     icon_down_arrow(),br(),
     # Step 5: Ensure Your Variant Dataset Sample Names Match Your CNV (GISTIC) Sample Names ------------------------------------------------------------------
     shinyWidgets::panel(
       heading = "Step 5: Ensure your SNV vs CNV (GISTIC) sample names match",
-      plotOutput(outputId = ns("out_plot_sample_name_overlap"), height = "300px", width="auto")
+      plotOutput(outputId = ns("out_plot_sample_name_overlap"), height = "300px", width="auto") %>% shinycssloaders::withSpinner()
     ),
     icon_down_arrow(break_after = TRUE),
     
@@ -102,7 +110,18 @@ mod_cnv_server <- function(id, maf_data_pool){
     #observe({ maf_dataset_wrapper_validated() ; maf() })
     maf <- reactive({ maf_dataset_wrapper_validated()$loaded_data })
 
-
+    use_inbuilt_gistic <- reactive({input[["in_bttn_preloaded_or_user"]] == "Inbuilt"})
+    
+    # Choose where to get your user input from
+    observeEvent(use_inbuilt_gistic(), isolate({
+      if(!use_inbuilt_gistic()){
+        updateTabsetPanel(session = session, inputId = "in_tabset", selected = "Custom")
+        #shinyjs::hide(id = input[["in_pick_gistic"]])
+      }
+      else if(use_inbuilt_gistic())
+        updateTabsetPanel(session = session, inputId = "in_tabset", selected = "Inbuilt")
+    }))
+    
     
 
     # Select Gistic Files -----------------------------------------------------
@@ -110,37 +129,61 @@ mod_cnv_server <- function(id, maf_data_pool){
     #   input[['in_file_gistic_data']]$datapath
     #   })
     
-    all_files_supplied <- reactive({
-      in_file_ids <- c("in_file_lesions", "in_file_amp", "in_file_del",  "in_file_scores")
-      #browser()
-      all(vapply(in_file_ids, function(id) { !is.null(input[[id]]) && nchar(input[[id]]$datapath) > 0}, FUN.VALUE = logical(1)))
+    gistic_selected <- reactive({
+      !is.null(input[["in_pick_gistic"]]) && nchar(input[["in_pick_gistic"]]) > 0
     })
 
     
     gistic <- reactive({
-      validate(need(all_files_supplied(), message = "Please supply gistic files"))
-      gistic_ <- tryCatch(
-        expr = { 
-          maftools::readGistic(
-            gisticAllLesionsFile = input[["in_file_lesions"]]$datapath,
-            gisticAmpGenesFile = input[["in_file_amp"]]$datapath, 
-            gisticDelGenesFile = input[["in_file_del"]]$datapath,
-            gisticScoresFile = input[["in_file_scores"]]$datapath, 
-            cnLevel = input[["in_check_cn_level"]], 
-            isTCGA = input[["in_check_is_tcga"]],
-          )
-        },
-        error = function(err){
-          shinyWidgets::sendSweetAlert(session = session, title = "Failed to Read Gistic", text = tags$span(tags$code(as.character(err))))
-          validate("Failed to Read Gistic")
-        },
-        warning = function(warn){
-          shinyWidgets::sendSweetAlert(session = session, title = "Failed to Read Gistic", text = tags$span(tags$code(as.character(warn))))
-          validate("Failed to Read Gistic")
-        }
+      
+      # If we use inbuilt gistic
+      if(use_inbuilt_gistic()){
+        validate(need(gistic_selected(), message = "Please select a gistic dataset"))
+        gistic_ <- tryCatch(
+          expr = { 
+            
+            index <- as.numeric(input[["in_pick_gistic"]])
+            cohort <- df_tcga_gistic[["Cohort"]][index]
+            source <- df_tcga_gistic[["Source"]][index]
+            cnLevel <- df_tcga_gistic[["CopyNumberLevel"]][index]
+            
+            gistic_ <- TCGAgistic::tcga_gistic_load(cohort = cohort, source = source, cnLevel = cnLevel, verbose = FALSE)
+          },
+          error = function(err){
+            shinyWidgets::sendSweetAlert(session = session, title = "Failed to Read Gistic", text = tags$span(tags$code(as.character(err))))
+            validate("Failed to Read Gistic")
+          },
+          warning = function(warn){
+            shinyWidgets::sendSweetAlert(session = session, title = "Failed to Read Gistic", text = tags$span(tags$code(as.character(warn))))
+            validate("Failed to Read Gistic")
+          }
+          
+        )
+        return(gistic_)
+      }
+      # If we use user-supplied gistic
+      else{
+        validate(need(!is.null(input[["in_file_gistic"]]$datapath), message = "Please supply a valid GISTIC2 rds file"))
         
-      )
-      return(gistic_)
+        gistic_ <- tryCatch(
+         expr = { 
+           readRDS(file = input[["in_file_gistic"]]$datapath)
+         },
+         error = function(err){
+           shinyWidgets::sendSweetAlert(session = session, title = "Failed to Read Gistic", text = tags$span(tags$code(as.character(err))))
+           validate("Please supply a valid Gistic RDS")
+         },
+         warning = function(warn){
+           shinyWidgets::sendSweetAlert(session = session, title = "Failed to Read Gistic", text = tags$span(tags$code(as.character(warn))))
+           validate("Please supply a valid Gistic RDS")
+         }
+       ) 
+        return(gistic_)
+    
+      }
+        
+      
+      
     })
   
     
@@ -148,7 +191,7 @@ mod_cnv_server <- function(id, maf_data_pool){
     
     output$out_plot_sample_name_overlap <- renderPlot({
       validate(need(!is.null(maf()), message = "Dataset failed to load"))
-      maftools_maf_and_gistic_sample_name_overlap_venn(maf = maf(), gistic = gistic())
+      maftools_maf_and_gistic_sample_name_overlap_venn(maf = maf(), gistic = gistic()) 
     })
     
     

--- a/R/mod_cnv.R
+++ b/R/mod_cnv.R
@@ -24,7 +24,7 @@ mod_cnv_ui <- function(id){
     
     # Step 2: Select GISTIC directory -----------------------------------------
     shinyWidgets::panel(
-      heading = "Step 2: Are you using inbuild GISTIC data or importing your own?",
+      heading = "Step 2: Are you using inbuilt GISTIC data or importing your own?",
       shinyWidgets::radioGroupButtons(
       inputId = ns("in_bttn_preloaded_or_user"),
       label = "Label",
@@ -167,7 +167,9 @@ mod_cnv_server <- function(id, maf_data_pool){
         
         gistic_ <- tryCatch(
          expr = { 
-           readRDS(file = input[["in_file_gistic"]]$datapath)
+           g <- readRDS(file = input[["in_file_gistic"]]$datapath)
+           if(!inherits(g, "GISTIC")) 
+             shinyWidgets::sendSweetAlert(session = session, title = "Failed to Read Gistic", text = tags$span(tags$code("RDS file does not encode a GISTIC object.")))
          },
          error = function(err){
            shinyWidgets::sendSweetAlert(session = session, title = "Failed to Read Gistic", text = tags$span(tags$code(as.character(err))))

--- a/R/mod_cnv.R
+++ b/R/mod_cnv.R
@@ -12,61 +12,86 @@ num_gistic_choices <- seq_len(nrow(df_tcga_gistic))
 mod_cnv_ui <- function(id){
   ns <- NS(id)
   tagList(
-    #mod_select_maf_dataset_wrapper_ui(id = ns("mod_select_maf_dataset_wrapper"))
-    #all_lesions.conf_XX.txt, amp_genes.conf_XX.txt, del_genes.conf_XX.txt and scores.gistic, where XX is the confidence level.
+  
     
-    # Step 1: Import Data -----------------------------------------------------
+  
+    # Step 1: Choose inbuilt VS custom -----------------------------------------
     shinyWidgets::panel(
-      heading = "Step 1: Select Dataset",
+      heading = "Step 1: Are you using inbuilt GISTIC data or importing your own?",
+      shinyWidgets::radioGroupButtons(
+        inputId = ns("in_bttn_preloaded_or_user"),
+        label = NULL,
+        choices = c("Inbuilt", "Custom"),
+        justified = TRUE)
+    ), icon_down_arrow(break_after = TRUE),
+    
+    # Step 1: Select GISTIC data -----------------------------------------
+    shinyWidgets::panel(
+      heading = HTML(paste0("Step 2: Select GISTIC (CNV) Data ", as.character(select_gistic_help_icon()), sep = " ")),
+      
+      tabsetPanel(
+        id = ns("in_tabset"), 
+        type = "hidden",
+        tabPanelBody(
+          value = "Inbuilt",
+          
+          fluidRow(
+            shinyWidgets::pickerInput(
+              inputId = ns("in_pick_gistic"), 
+              label = "Select CNV dataset", 
+              choices = seq_len(nrow(df_tcga_gistic)), width = "100%",
+              options = list(title = "Please select a GISTIC dataset", `live-search`=TRUE),
+              choicesOpt = list(
+                content = paste0(
+                  TCGAgistic::tcga_gistic_available()[[2]],
+                  " ",
+                  TCGAgistic::tcga_gistic_available()[[4]] %>% paste0("<span class='label label-default' style='margin-left: 10px; font-size: xx-small' >",., "</span>"),
+                  " ",
+                  TCGAgistic::tcga_gistic_available()[[1]] %>% paste0("<span class='label label-default' style='margin-left: 10px; font-size: xx-small' >",., "</span>"),
+                  " ",
+                  "TCGA" %>% paste0("<span class='label label-default' style='margin-left: 10px; font-size: xx-small' >",., "</span>")
+                )
+              )) %>% col_4(),
+            shinydashboard::box(
+              title = "CNV (GISTIC) datasets", width = "100%",
+              "
+              GISTIC2 is a toolkit that takes copynumber data for a cohort and identifies strong &/or recurrent amplifications/deletions.
+              For TCGA datasets, use the inbuilt GISTIC datasets. Shallow/Deep/All refers to size of the CNVs to display.
+              "
+            ) %>% col_8()
+          )
+        ),
+        tabPanelBody(
+          value = "Custom",
+          fluidRow(
+          fileInput(inputId = ns("in_file_gistic"), label = "Select your GISTIC rds", width = "100%") %>% col_4(),
+          shinydashboard::box(
+            title = "Creating your own (GISTIC) datasets", width = "100%",
+            "
+            GISTIC2 is a toolkit that takes copynumber data for a cohort and identifies strong and/or recurrent amplifications/deletions.
+            For custom datasets:
+            Run GISTIC on th genepattern server -> convert to a CRUX RDS using CCICB/interchangeGUI -> Import Here.
+            "
+          ) %>% col_8()
+          )
+          
+        ),
+      )
+    ),
+    icon_down_arrow(),br(),
+    
+    # Step 1: Import Mutational Data -----------------------------------------------------
+    shinyWidgets::panel(
+      heading = "Step 3: Select Dataset",
       mod_select_maf_dataset_wrapper_ui(id = ns("mod_select_dataset_wrapper"), panel = FALSE)
     ),
     icon_down_arrow(break_after = TRUE),
     
-    # Step 2: Select GISTIC directory -----------------------------------------
-    shinyWidgets::panel(
-      heading = "Step 2: Are you using inbuilt GISTIC data or importing your own?",
-      shinyWidgets::radioGroupButtons(
-      inputId = ns("in_bttn_preloaded_or_user"),
-      label = "Label",
-      choices = c("Inbuilt", "Custom"),
-      justified = TRUE)
-    ), icon_down_arrow(break_after = TRUE),
+   
     
-    shinyWidgets::panel(
-      heading = HTML(paste0("Step 3: Select GISTIC files", as.character(select_gistic_help_icon()), sep = " ")),
-    
-      tabsetPanel(id = ns("in_tabset"), type = "hidden",
-        tabPanelBody(
-          value = "Inbuilt",
-          shinyWidgets::pickerInput(
-            inputId = ns("in_pick_gistic"), 
-            label = "Select CNV dataset", 
-            choices = seq_len(nrow(df_tcga_gistic)) ,
-            options = list(title = "Please select a GISTIC dataset"),
-            choicesOpt = list(
-              content = paste0(
-                TCGAgistic::tcga_gistic_available()[[2]],
-                " ",
-                TCGAgistic::tcga_gistic_available()[[4]] %>% paste0("<span class='label label-default' style='margin-left: 10px; font-size: xx-small' >",., "</span>"),
-                " ",
-                TCGAgistic::tcga_gistic_available()[[1]] %>% paste0("<span class='label label-default' style='margin-left: 10px; font-size: xx-small' >",., "</span>"),
-                " ",
-                "TCGA" %>% paste0("<span class='label label-default' style='margin-left: 10px; font-size: xx-small' >",., "</span>")
-                
-              ) 
-            ))    
-          ),
-        tabPanelBody(
-          value = "Custom",
-          fileInput(inputId = ns("in_file_gistic"), label = "Select your GISTIC rds")
-         ),
-      )
-    ),
-    
-    icon_down_arrow(),br(),
     # Step 5: Ensure Your Variant Dataset Sample Names Match Your CNV (GISTIC) Sample Names ------------------------------------------------------------------
     shinyWidgets::panel(
-      heading = "Step 5: Ensure your SNV vs CNV (GISTIC) sample names match",
+      heading = "Step 4: Ensure your SNV vs CNV (GISTIC) sample names match",
       plotOutput(outputId = ns("out_plot_sample_name_overlap"), height = "300px", width="auto") %>% shinycssloaders::withSpinner()
     ),
     icon_down_arrow(break_after = TRUE),
@@ -74,7 +99,7 @@ mod_cnv_ui <- function(id){
     
     # Step 6: Analyse / Visualise ------------------------------------------------------------------
     shinyWidgets::panel(
-      heading = "Step 6: Choose Analysis / Visualisation",
+      heading = "Step 5: Choose Analysis / Visualisation",
       tabsetPanel(
         tabPanel(title = "Genome Plot", mod_plot_gistic_genome_ui(ns("mod_plot_genome"))),
         tabPanel(title = "Oncoplot", mod_plot_gistic_oncoplot_ui(ns("mod_plot_oncoplot")))
@@ -201,369 +226,9 @@ mod_cnv_server <- function(id, maf_data_pool){
     # Analyses ----------------------------------------------------------------
     mod_plot_gistic_genome_server("mod_plot_genome", gistic=gistic, maf = maf)
     mod_plot_gistic_oncoplot_server("mod_plot_oncoplot", gistic=gistic, maf=maf)
-    # output$out_dt_cytoband_summary <- mod_render_downloadabledataframe_server(id = "mod_downloadable_df_cytoband_summary", tabular_data_object = cytoband_summary_df, basename = "GISTIC_Cytoband_Summary")
-    # output$out_dt_sample_summary <- mod_render_downloadabledataframe_server(id = "mod_downloadable_df_sample_summary", tabular_data_object =  sample_summary_df, "GISTIC_Sample_Summary")
-    # output$out_dt_gene_summary <- mod_render_downloadabledataframe_server(id = "mod_downloadable_df_gene_summary", tabular_data_object =  gene_summary_df, "GISTIC_Gene_Summary")
-    # mod_render_downloadabledataframe_server(id = "mod_downloadable_df_oncoplot_data", tabular_data_object = oncoplot_data_df, basename = "GISTIC_Oncoplot_Data")
-    
-    # gistic_folder <- mod_shinydir_import_server(id = "mod_select_gistic_dir")
-    # gistic_folder_validated <- reactive({ validate(need(!is.null(gistic_folder()) && length(gistic_folder()) > 0,message = "Please select a valid gistic folder" )); return(gistic_folder()) })
-    # 
-    # 
-    # # Output Gistic Folder Path -----------------------------------------------
-    # output$out_text_directory <- renderText({ gistic_folder_validated() })
-    # 
-    # #Look Inside the folder and grab the results ---------------------------------------------
-    # observeEvent(gistic_folder_validated(), {
-    #   # browser()
-    #   contents.v <- dir(gistic_folder_validated(), recursive = FALSE, full.names = FALSE)
-    #   selected_lesions <- dir(gistic_folder_validated(), pattern = "all_lesions.conf_..\\.txt", recursive = FALSE, full.names = FALSE)
-    #   amplified_genes <- dir(gistic_folder_validated(), pattern = "amp_genes.conf_..\\.txt", recursive = FALSE, full.names = FALSE)
-    #   deleted_genes <- dir(gistic_folder_validated(), pattern = "del_genes.conf_..\\.txt", recursive = FALSE, full.names = FALSE)
-    #   scores <- dir(gistic_folder_validated(), pattern = "scores.gistic", recursive = FALSE, full.names = FALSE)
-    #   
-    #   if(length(selected_lesions) > 0 && length(amplified_genes) > 0 && length(deleted_genes) > 0 && length(scores) > 0)
-    #     directory_looks_like_gistic(TRUE)
-    #   else 
-    #     directory_looks_like_gistic(FALSE)
-    #   
-    #   
-    #   shinyWidgets::updatePickerInput(session = session, inputId = "in_file_lesions", choices = contents.v, selected = dplyr::first(selected_lesions))
-    #   shinyWidgets::updatePickerInput(session = session, inputId = "in_file_amp", choices = contents.v, selected = dplyr::first(amplified_genes))
-    #   shinyWidgets::updatePickerInput(session = session, inputId = "in_file_del", choices = contents.v, selected = dplyr::first(deleted_genes))
-    #   shinyWidgets::updatePickerInput(session = session, inputId = "in_file_scores", choices = contents.v, selected = dplyr::first(scores))
-    # })
-    # 
-    # 
-    # # Check if folder looks like gistic ---------------------------------------------------
-    # output$out_dir_looks_like_gistic <- renderText({
-    #   if(is.null(gistic_folder()) || length(gistic_folder()) < 1) return(NULL)
-    #   
-    #   if(directory_looks_like_gistic()){
-    #     p("The folder you picked looks like GISTIC output!", class="alert-success", gistic_check_circle()) %>% as.character() %>% return()
-    #   }
-    #   else
-    #     p("Current folder does not look like GISTIC output! If you just renamed the gistic files, then continue (specify appropriate files in step 3). Otherwise, please pause and make sure the folder was generated by GISTIC", class="alert-danger", gistic_bad_path()) %>% as.character() %>% return()
-    # })
-    # 
-    # 
-    # # Derive paths for each file---------------------------------------------------
-    # lesion_path <- reactive({
-    #   #browser()
-    #   validate(need(!is.null(input$in_file_lesions) && length(input$in_file_lesions) > 0, message = "Please select a lesions file (all_lesions.conf_[threshold].txt)"))
-    #   paste0(gistic_folder_validated(), "/", input$in_file_lesions) %>% return()
-    #   # else
-    #   #   return(NULL)
-    # })
-    # amp_path <- reactive({
-    #   validate(need(!is.null(input$in_file_amp) && length(input$in_file_amp) > 0, message = "Please select an amplified genes file (amp_genes.conf_[threshold].txt)"))
-    #   paste0(gistic_folder_validated(), "/", input$in_file_amp) %>% return()
-    #   # else
-    #   #   return(NULL)
-    # })
-    # del_path <- reactive({
-    #   validate(need(!is.null(input$in_file_del) && length(input$in_file_del) > 0, message = "Please select a deleted genes file (del_genes.conf_[threshold].txt)"))
-    #   paste0(gistic_folder_validated(), "/", input$in_file_del) %>% return()
-    #   # else
-    #   #   return(NULL)
-    # })
-    # scores_path <- reactive({
-    #   # browser()
-    #   validate(need(!is.null(input$in_file_scores) && length(input$in_file_scores) > 0, message = "Please select a gistic.scores file (scores.gistic)"))
-    #   paste0(gistic_folder_validated(), "/", input$in_file_scores) %>% return()
-    #   # else
-    #   #   return(NULL)
-    # })
-    # 
-    # # Create gistic object -------------------------------------------------
-    # gistic <- reactive({ 
-    #   gistic_folder_validated() #Just here to trigger a validation message if no gistic folder is selected
-    #   tryCatch(
-    #     expr = { 
-    #       maftools::readGistic(
-    #         gisticAllLesionsFile = lesion_path(),
-    #         gisticAmpGenesFile = amp_path(), 
-    #         gisticDelGenesFile = del_path(), 
-    #         gisticScoresFile = scores_path(), 
-    #         isTCGA = input$in_check_is_tcga,
-    #         cnLevel = input$in_check_cn_level,
-    #       ) %>%
-    #         return()
-    #     },
-    #     error = function(err){
-    #       message("ERROR")
-    #       err=as.character(err)
-    #       validate(paste0("Problem with input files: \n\t", err))
-    #       return(NULL)
-    #     },
-    #     warn = function(warn){
-    #       message("WARNING")
-    #       warn=as.character(warn)
-    #       validate(paste0("Problem with input files: \n\t", warn))
-    #       return(NULL)
-    #     }
-    #   )
-    # })
-    # 
-    # 
-
-    # 
-    # 
-    # # Summaries ---------------------------------------------------------------
-    # cytoband_summary_df <- reactive({ validate(need(!is.null(gistic()), message = "Waiting for valid gistic")); maftools::getCytobandSummary(gistic()) })
-    # sample_summary_df <- reactive({ validate(need(!is.null(gistic()), message = "Waiting for valid gistic")); maftools::getSampleSummary(gistic()) })
-    # gene_summary_df <- reactive({ validate(need(!is.null(gistic()), message = "Waiting for valid gistic")); maftools::getGeneSummary(gistic()) })
-    # oncoplot_data_df <- reactive({ validate(need(!is.null(gistic()), message = "Waiting for valid gistic")); gistic()@data %>% type.convert(as.is=TRUE) })
-    # 
-    # # Analyses -----------------------------------------------------------------
-    # output$out_dt_cytoband_summary <- mod_render_downloadabledataframe_server(id = "mod_downloadable_df_cytoband_summary", tabular_data_object = cytoband_summary_df, basename = "GISTIC_Cytoband_Summary")
-    # output$out_dt_sample_summary <- mod_render_downloadabledataframe_server(id = "mod_downloadable_df_sample_summary", tabular_data_object =  sample_summary_df, "GISTIC_Sample_Summary")
-    # output$out_dt_gene_summary <- mod_render_downloadabledataframe_server(id = "mod_downloadable_df_gene_summary", tabular_data_object =  gene_summary_df, "GISTIC_Gene_Summary")
-    # #output$out_dt_oncoplot_summary <-
-    # mod_render_downloadabledataframe_server(id = "mod_downloadable_df_oncoplot_data", tabular_data_object = oncoplot_data_df, basename = "GISTIC_Oncoplot_Data")
-    # 
-    # mod_plot_gistic_genome_server("mod_plot_genome", gistic=gistic, maf=maf)
-    # mod_plot_gistic_oncoplot_server("mod_plot_oncoplot", gistic=gistic, maf=maf)
     
   })
 }
-
-#' cnv UI Function
-#'
-#' @description A shiny Module.
-#'
-#' @param id,input,output,session Internal parameters for {shiny}.
-#'
-#' @noRd 
-#'
-#' @importFrom shiny NS tagList 
-mod_cnv_ui2 <- function(id){
-  ns <- NS(id)
-  tagList(
-    #mod_select_maf_dataset_wrapper_ui(id = ns("mod_select_maf_dataset_wrapper"))
-    #all_lesions.conf_XX.txt, amp_genes.conf_XX.txt, del_genes.conf_XX.txt and scores.gistic, where XX is the confidence level.
-    
-    # Step 1: Import Data -----------------------------------------------------
-    shinyWidgets::panel(
-      heading = "Step 1: Select Dataset",
-      mod_select_maf_dataset_wrapper_ui(id = ns("mod_select_dataset_wrapper"), panel = FALSE)
-    ),
-    icon_down_arrow(),br(),
-    
-    # Step 2: Select GISTIC directory -----------------------------------------
-    shinyWidgets::panel(
-      heading = HTML(paste0("Step 2: Select GISTIC directory   ", as.character(select_gistic_help_icon()), sep = " ")),
-      mod_shinydir_import_ui(
-        id = ns("mod_select_gistic_dir"), 
-        title = "Gistic Output Directory", 
-        label = "Select GISTIC folder", 
-        buttonType = "primary"
-      ),
-      
-      wellPanel(textOutput(outputId = ns("out_text_directory"))),
-      htmlOutput(outputId = ns("out_dir_looks_like_gistic"))
-    ),
-    icon_down_arrow(),br(),
-
-    # Step 3: Check automatic identification of GISTIC files ------------------
-    shinyWidgets::panel(
-      heading = HTML(paste0("Step 3: Check automatic identification of required gistic files is correct", "      ", gistic_help_icon())),
-      fluidRow(
-        shinyWidgets::pickerInput(inputId = ns("in_file_lesions"), label = "All Lesions", choices = NULL) %>% col_3(),
-        shinyWidgets::pickerInput(inputId = ns("in_file_amp"), label = "Amplified Genes", choices = NULL) %>% col_3(),
-        shinyWidgets::pickerInput(inputId = ns("in_file_del"), label = "Deleted Genes", choices = NULL) %>% col_3(),
-        shinyWidgets::pickerInput(inputId = ns("in_file_scores"), label = "Scores", choices = NULL) %>% col_3()
-        
-      )
-    ),
-    icon_down_arrow(),br(),
-
-    # Step 4: Configure Analysis ----------------------------------------------
-    shinyWidgets::panel(
-      heading = "Step 4: Configure Analysis",
-      fluidRow(
-      shinyWidgets::awesomeCheckbox(inputId = ns("in_check_is_tcga"), label = "Data is from TCGA", value = FALSE) %>% 
-        bsplus::bs_embed_tooltip(title = "Is the GISTIC data from a TCGA project? If so, we truncate the Tumor_Sample_Barcodes to patient level rather than sequencing_run level",placement = "top") %>%
-         col_2(),
-      shinyWidgets::awesomeRadio(inputId = ns("in_check_cn_level"), label = HTML(paste0("cnLevel", icon(""))), choices = c("all", "deep", "shallow"), selected = "all", inline = TRUE) %>%
-        bsplus::bs_embed_tooltip(title = "Level of CN changes to use. Can be 'all', 'deep' or 'shallow'. Default uses all i.e, genes with both 'shallow' or 'deep' CN changes", placement="top") %>% 
-        col_4() 
-      )
-    ),
-    icon_down_arrow(),br(),
-    # Step 5: Ensure Your Variant Dataset Sample Names Match Your CNV (GISTIC) Sample Names ------------------------------------------------------------------
-    shinyWidgets::panel(
-      heading = "Step 5: Ensure your SNV vs CNV (GISTIC) sample names match",
-      plotOutput(outputId = ns("out_plot_sample_name_overlap"), height = "300px", width="auto")
-    ),
-    icon_down_arrow(),br(),
-    
-
-    # Step 6: Analyse / Visualise ------------------------------------------------------------------
-    shinyWidgets::panel(
-      heading = "Step 6: Choose Analysis / Visualisation",
-      tabsetPanel(
-        tabPanel(title = "Genome Plot", mod_plot_gistic_genome_ui(ns("mod_plot_genome"))),
-        tabPanel(title = "Oncoplot", mod_plot_gistic_oncoplot_ui(ns("mod_plot_oncoplot"))),
-        tabPanel(title = "Oncoplot Summary", mod_render_downloadabledataframe_ui(id=ns("mod_downloadable_df_oncoplot_data"))),
-        tabPanel(title = "Gene Summary", mod_render_downloadabledataframe_ui(id=ns("mod_downloadable_df_gene_summary"))),
-        tabPanel(title = "Sample Summary", mod_render_downloadabledataframe_ui(id=ns("mod_downloadable_df_sample_summary"))),
-        tabPanel(title = "Cytoband Summary", mod_render_downloadabledataframe_ui(id=ns("mod_downloadable_df_cytoband_summary")))
-      ),
-      br()
-    )
-  )
-}
-
-#' cnv Server Functions
-#'
-#' @noRd 
-mod_cnv_server2 <- function(id, maf_data_pool){
-  utilitybeltshiny::assert_reactive(maf_data_pool)
-  
-  moduleServer( id, function(input, output, session){
-    ns <- session$ns
-    
-    
-    # ReactiveVal ------------------------------------------------------------
-    directory_looks_like_gistic <- reactiveVal(FALSE)
-    
-    
-    
-    # Step 1: Import Data -----------------------------------------------------
-    maf_dataset_wrapper <- mod_select_maf_dataset_wrapper_server(id = "mod_select_dataset_wrapper", maf_data_pool = maf_data_pool)
-    maf_dataset_wrapper_validated <- reactive({ validate(need(!is.null(maf_dataset_wrapper()),message = "Loading ..." )); return(maf_dataset_wrapper()) })
-    #observe({ maf_dataset_wrapper_validated() ; maf() })
-    maf <- reactive({ maf_dataset_wrapper_validated()$loaded_data })
-    
-    gistic_folder <- mod_shinydir_import_server(id = "mod_select_gistic_dir")
-    gistic_folder_validated <- reactive({ validate(need(!is.null(gistic_folder()) && length(gistic_folder()) > 0,message = "Please select a valid gistic folder" )); return(gistic_folder()) })
-    
-    
-    # Output Gistic Folder Path -----------------------------------------------
-    output$out_text_directory <- renderText({ gistic_folder_validated() })
-    
-    #Look Inside the folder and grab the results ---------------------------------------------
-    observeEvent(gistic_folder_validated(), {
-      
-      contents.v <- dir(gistic_folder_validated(), recursive = FALSE, full.names = FALSE)
-      selected_lesions <- dir(gistic_folder_validated(), pattern = "all_lesions.conf_..\\.txt", recursive = FALSE, full.names = FALSE)
-      amplified_genes <- dir(gistic_folder_validated(), pattern = "amp_genes.conf_..\\.txt", recursive = FALSE, full.names = FALSE)
-      deleted_genes <- dir(gistic_folder_validated(), pattern = "del_genes.conf_..\\.txt", recursive = FALSE, full.names = FALSE)
-      scores <- dir(gistic_folder_validated(), pattern = "scores.gistic", recursive = FALSE, full.names = FALSE)
-      
-      if(length(selected_lesions) > 0 && length(amplified_genes) > 0 && length(deleted_genes) > 0 && length(scores) > 0)
-        directory_looks_like_gistic(TRUE)
-      else 
-        directory_looks_like_gistic(FALSE)
-      
-      
-      shinyWidgets::updatePickerInput(session = session, inputId = "in_file_lesions", choices = contents.v, selected = dplyr::first(selected_lesions))
-      shinyWidgets::updatePickerInput(session = session, inputId = "in_file_amp", choices = contents.v, selected = dplyr::first(amplified_genes))
-      shinyWidgets::updatePickerInput(session = session, inputId = "in_file_del", choices = contents.v, selected = dplyr::first(deleted_genes))
-      shinyWidgets::updatePickerInput(session = session, inputId = "in_file_scores", choices = contents.v, selected = dplyr::first(scores))
-    })
-    
-    
-    # Check if folder looks like gistic ---------------------------------------------------
-    output$out_dir_looks_like_gistic <- renderText({
-      if(is.null(gistic_folder()) || length(gistic_folder()) < 1) return(NULL)
-      
-      if(directory_looks_like_gistic()){
-        p("The folder you picked looks like GISTIC output!", class="alert-success", gistic_check_circle()) %>% as.character() %>% return()
-      }
-      else
-        p("Current folder does not look like GISTIC output! If you just renamed the gistic files, then continue (specify appropriate files in step 3). Otherwise, please pause and make sure the folder was generated by GISTIC", class="alert-danger", gistic_bad_path()) %>% as.character() %>% return()
-    })
-    
-    
-    # Derive paths for each file---------------------------------------------------
-    lesion_path <- reactive({
-      #browser()
-      validate(need(!is.null(input$in_file_lesions) && length(input$in_file_lesions) > 0, message = "Please select a lesions file (all_lesions.conf_[threshold].txt)"))
-      paste0(gistic_folder_validated(), "/", input$in_file_lesions) %>% return()
-      # else
-      #   return(NULL)
-    })
-    amp_path <- reactive({
-      validate(need(!is.null(input$in_file_amp) && length(input$in_file_amp) > 0, message = "Please select an amplified genes file (amp_genes.conf_[threshold].txt)"))
-      paste0(gistic_folder_validated(), "/", input$in_file_amp) %>% return()
-      # else
-      #   return(NULL)
-    })
-    del_path <- reactive({
-      validate(need(!is.null(input$in_file_del) && length(input$in_file_del) > 0, message = "Please select a deleted genes file (del_genes.conf_[threshold].txt)"))
-      paste0(gistic_folder_validated(), "/", input$in_file_del) %>% return()
-      # else
-      #   return(NULL)
-    })
-    scores_path <- reactive({
-      # browser()
-      validate(need(!is.null(input$in_file_scores) && length(input$in_file_scores) > 0, message = "Please select a gistic.scores file (scores.gistic)"))
-      paste0(gistic_folder_validated(), "/", input$in_file_scores) %>% return()
-      # else
-      #   return(NULL)
-    })
-    
-    # Create gistic object -------------------------------------------------
-    gistic <- reactive({ 
-      gistic_folder_validated() #Just here to trigger a validation message if no gistic folder is selected
-      tryCatch(
-        expr = { 
-          maftools::readGistic(
-            gisticAllLesionsFile = lesion_path(),
-            gisticAmpGenesFile = amp_path(), 
-            gisticDelGenesFile = del_path(), 
-            gisticScoresFile = scores_path(), 
-            isTCGA = input$in_check_is_tcga,
-            cnLevel = input$in_check_cn_level,
-          ) %>%
-            return()
-        },
-        error = function(err){
-          message("ERROR")
-          err=as.character(err)
-          validate(paste0("Problem with input files: \n\t", err))
-          return(NULL)
-        },
-        warn = function(warn){
-          message("WARNING")
-          warn=as.character(warn)
-          validate(paste0("Problem with input files: \n\t", warn))
-          return(NULL)
-        }
-      )
-    })
-    
-
-    # Sample Name Overlap -----------------------------------------------------
-
-    output$out_plot_sample_name_overlap <- renderPlot({
-      validate(need(!is.null(maf()), message = "Dataset failed to load"))
-      maftools_maf_and_gistic_sample_name_overlap_venn(maf = maf(), gistic = gistic())
-    })
-    
-    
-    # Summaries ---------------------------------------------------------------
-    cytoband_summary_df <- reactive({ validate(need(!is.null(gistic()), message = "Waiting for valid gistic")); maftools::getCytobandSummary(gistic()) })
-    sample_summary_df <- reactive({ validate(need(!is.null(gistic()), message = "Waiting for valid gistic")); maftools::getSampleSummary(gistic()) })
-    gene_summary_df <- reactive({ validate(need(!is.null(gistic()), message = "Waiting for valid gistic")); maftools::getGeneSummary(gistic()) })
-    oncoplot_data_df <- reactive({ validate(need(!is.null(gistic()), message = "Waiting for valid gistic")); gistic()@data %>% type.convert(as.is=TRUE) })
-    
-    # Analyses -----------------------------------------------------------------
-    output$out_dt_cytoband_summary <- mod_render_downloadabledataframe_server(id = "mod_downloadable_df_cytoband_summary", tabular_data_object = cytoband_summary_df, basename = "GISTIC_Cytoband_Summary")
-    output$out_dt_sample_summary <- mod_render_downloadabledataframe_server(id = "mod_downloadable_df_sample_summary", tabular_data_object =  sample_summary_df, "GISTIC_Sample_Summary")
-    output$out_dt_gene_summary <- mod_render_downloadabledataframe_server(id = "mod_downloadable_df_gene_summary", tabular_data_object =  gene_summary_df, "GISTIC_Gene_Summary")
-    #output$out_dt_oncoplot_summary <-
-    mod_render_downloadabledataframe_server(id = "mod_downloadable_df_oncoplot_data", tabular_data_object = oncoplot_data_df, basename = "GISTIC_Oncoplot_Data")
-    
-    mod_plot_gistic_genome_server("mod_plot_genome", gistic=gistic, maf=maf)
-    mod_plot_gistic_oncoplot_server("mod_plot_oncoplot", gistic=gistic, maf=maf)
-    
-  })
-}
-
-
 
 
 # Bonus Functions ---------------------------------------------------------

--- a/R/mod_plot_gistic_oncoplot.R
+++ b/R/mod_plot_gistic_oncoplot.R
@@ -30,7 +30,7 @@ mod_plot_gistic_oncoplot_ui <- function(id){
         numericInput(ns("in_num_fontsize_annotations"), label = "Fontsize: Annotations", value = 1.2, min = 0.01, step = 0.1) %>% col_3()
       ),
       fluidRow(
-        numericInput(ns("in_num_mar_gene"), label = "Margin: Genes", value = 5, min = 0.01, step = 1) %>% col_3(),
+        numericInput(ns("in_num_mar_gene"), label = "Margin: Genes", value = 6, min = 0.01, step = 1) %>% col_3(),
         numericInput(ns("in_num_mar_barcodes"), label = "Margin: Barcodes", value = 5, min = 0.01, step = 1) %>% col_3(),
         numericInput(ns("in_num_sepwd_genes"), label = "Sepwd: Genes", value = 0.5, min = 0.01, step = 1) %>% col_3(),
         numericInput(ns("in_num_sepwd_samples"), label = "Sepwd: Samples", value = 0.25, min = 0.01, step = 1) %>% col_3()

--- a/man/icon_down_arrow.Rd
+++ b/man/icon_down_arrow.Rd
@@ -4,7 +4,7 @@
 \alias{icon_down_arrow}
 \title{icon_down_arrow}
 \usage{
-icon_down_arrow(fontsize = "40px", alignment = "center")
+icon_down_arrow(fontsize = "40px", alignment = "center", break_after = FALSE)
 }
 \arguments{
 \item{fontsize}{a valid css fontsize, e.g. 60px (string)}


### PR DESCRIPTION
Prebuilt maftools gistic object are within CRUX via a dropdown menu, all powered by the CCICB/TCGAgistic package

Users can alternatively supply their own GISTIC object in RDS form. We should get  CCICB/interchangeGUI live  before CRUX goes out to allow Gistic ZIP conversion to  maftools GISTIC object. Basic functionality is already in CCICB/interchange